### PR TITLE
refactor code and fix unary printer

### DIFF
--- a/src/source_print.rs
+++ b/src/source_print.rs
@@ -61,12 +61,12 @@ impl Display for OCamlLiteral {
     }
 }
 
-impl Display for OCamlUnaryOperator {
+impl Display for OCamlUnaryExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OCamlUnaryOperator::Minus(neg) => write!(f, "-{}", neg),
-            OCamlUnaryOperator::Not(not) => write!(f, "{}", not),
-            OCamlUnaryOperator::Deref(star) => write!(f, "{}", star),
+            Self::Minus(neg) => write!(f, "-({})", neg),
+            Self::Not(not) => write!(f, "!({})", not),
+            Self::Deref(star) => write!(f, "{}", star),
         }
     }
 }

--- a/src/source_print.rs
+++ b/src/source_print.rs
@@ -21,9 +21,7 @@ impl Display for OCaml {
             OCaml::Let { name, ty, value } => match (ty, value) {
                 (Some(ty), None) => write!(f, "let {} : {}", name, ty),
                 (None, Some(value)) => write!(f, "let {} = {}", name, value),
-                (Some(ty), Some(value)) => {
-                    write!(f, "let {} : {} = {}", name, ty, value)
-                }
+                (Some(ty), Some(value)) => write!(f, "let {} : {} = {}", name, ty, value),
                 (None, None) => Ok(()),
             },
             OCaml::Statements(s) => {
@@ -43,10 +41,7 @@ impl Display for OCamlExpr {
             OCamlExpr::Path(p) => write!(
                 f,
                 "{}",
-                p.iter()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<String>>()
-                    .join(".")
+                p.join(".")
             ),
             OCamlExpr::Unary(unary) => write!(f, "{}", unary),
         }


### PR DESCRIPTION
1. Add tuple struct `SynPath` and `SynType` to allow `from` trait
2. Rename `OCamlUnaryOperator` to `OCamlUnaryExpr`
3. Fix the unary printer by wrapping expressions in parentheses to avoid bugs.