### PR TITLE
Add Error Handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,23 @@
 mod ocaml;
 mod source_print;
 
+use std::process::exit;
+
 use ocaml::*;
 use source_print::*;
 
 fn main() {
     let rust_file = "empty.rs";
     let ocaml_file = "libc.ml";
-    let ocaml_ast = OCaml::from_rust_file(rust_file);
+    
+    let ocaml_ast = match OCaml::from_rust_file(rust_file) {
+        Ok(ast) => ast,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            exit(1)
+        }
+    };
+
     let printer = SourcePrinter::from_ocaml_ast(ocaml_ast);
     printer.print_sources(ocaml_file);
 }

--- a/src/ocaml.rs
+++ b/src/ocaml.rs
@@ -48,7 +48,7 @@ impl OCaml {
             .map_err(|_| OCamlError::UnableToReadFile(file_path.to_string()))?;
 
         let syntax = syn::parse_file(&src).map_err(|e| {
-            OCamlError::Parse(format!("'{}': {}", file_path.to_string(), e.to_string()))
+            OCamlError::Parse(format!("'{}': {}", file_path, e))
         })?;
 
         //println!("{:#?}", syntax);


### PR DESCRIPTION
It allows the program not to panic if you're unable to parse the file, but rather, it returns a result type that you can decide to unwrap later on. This makes parsing multiple modules easier since errors in a single module do not affect the AST parsing of another module.